### PR TITLE
swtich to Docker Hub from Google Cloud Registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/tensorflow/tensorflow:1.3.0
+FROM tensorflow/tensorflow:1.3.0
 
 RUN pip install networkx==1.11
 RUN rm /notebooks/*

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,4 +1,4 @@
-FROM gcr.io/tensorflow/tensorflow:1.3.0-gpu
+FROM tensorflow/tensorflow:1.3.0-gpu
 
 RUN pip install networkx==1.11
 RUN rm /notebooks/*


### PR DESCRIPTION
Apparently, Tensorflow images are not served from GCR anymore. It is required to switch to Docker Hub [as recommended](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/tools/docker). 

Issue #38