### PR TITLE
Fixing a typo

### DIFF
--- a/graphsage/models.py
+++ b/graphsage/models.py
@@ -195,7 +195,7 @@ class SampleAndAggregate(GeneralizedModel):
             **kwargs):
         '''
         Args:
-            - placeholders: Stanford TensorFlow placeholder object.
+            - placeholders: Standard TensorFlow placeholder object.
             - features: Numpy array with node features. 
                         NOTE: Pass a None object to train in featureless mode (identity features for nodes)!
             - adj: Numpy array with adjacency lists (padded with random re-samples)

--- a/graphsage/supervised_models.py
+++ b/graphsage/supervised_models.py
@@ -17,7 +17,7 @@ class SupervisedGraphsage(models.SampleAndAggregate):
                 **kwargs):
         '''
         Args:
-            - placeholders: Stanford TensorFlow placeholder object.
+            - placeholders: Standard TensorFlow placeholder object.
             - features: Numpy array with node features.
             - adj: Numpy array with adjacency lists (padded with random re-samples)
             - degrees: Numpy array with node degrees. 


### PR DESCRIPTION
It seems that several appearances of "Standard" are written as "Stanford".
Please ignore me if this is deliberate :)